### PR TITLE
Fix power rankings container

### DIFF
--- a/src/app/power-rankings/power-rankings.component.html
+++ b/src/app/power-rankings/power-rankings.component.html
@@ -34,8 +34,9 @@
         [playerId]="samplePlayers[6]"
         [rank]="7">
         </app-player-card>
-        <app-player-card 
+        <app-player-card
         [playerId]="samplePlayers[7]"
         [rank]="8">
         </app-player-card>
     </div>
+</div>


### PR DESCRIPTION
## Summary
- close the `power-rankings__container` div

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655f5801f08327b7a26087c50704ca