### PR TITLE
Add Start.gg service

### DIFF
--- a/src/app/services/startgg.service.spec.ts
+++ b/src/app/services/startgg.service.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { StartggService } from './startgg.service';
+
+describe('StartggService', () => {
+  let service: StartggService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [StartggService]
+    });
+    service = TestBed.inject(StartggService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should parse tournament response', () => {
+    const mock = { data: { tournament: { id: 5, name: 'Test', slug: 'test' } } };
+    expect(service.mapTournament(mock)).toEqual({ id: 5, name: 'Test', slug: 'test' });
+  });
+
+  it('should parse players response', () => {
+    const mock = {
+      data: {
+        event: {
+          entrants: {
+            nodes: [
+              { id: '1', participants: [{ gamerTag: 'P1' }] },
+              { id: '2', participants: [{ gamerTag: 'P2' }] }
+            ]
+          }
+        }
+      }
+    };
+    expect(service.mapPlayers(mock)).toEqual([
+      { id: 1, tag: 'P1' },
+      { id: 2, tag: 'P2' }
+    ]);
+  });
+
+  it('should parse sets response', () => {
+    const mock = {
+      data: {
+        event: {
+          sets: {
+            nodes: [
+              {
+                id: '1',
+                winnerId: 1,
+                slots: [{ entrant: { id: '1' } }, { entrant: { id: '2' } }]
+              }
+            ]
+          }
+        }
+      }
+    };
+    expect(service.mapSets(mock)).toEqual([
+      { id: '1', winnerId: 1, entrantIds: [1, 2] }
+    ]);
+  });
+
+  it('should perform http request in getTournament', () => {
+    const mockResponse = { data: { tournament: { id: 5, name: 'Test', slug: 'test' } } };
+    service.getTournament('test').subscribe(t => {
+      expect(t).toEqual({ id: 5, name: 'Test', slug: 'test' });
+    });
+    const req = httpMock.expectOne('https://api.start.gg/gql/alpha');
+    expect(req.request.method).toBe('POST');
+    req.flush(mockResponse);
+  });
+});

--- a/src/app/services/startgg.service.ts
+++ b/src/app/services/startgg.service.ts
@@ -1,0 +1,69 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import { GgTournament, GgPlayer, GgSet } from 'src/models/startgg';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StartggService {
+  private apiUrl = 'https://api.start.gg/gql/alpha';
+
+  constructor(private http: HttpClient) {}
+
+  private get headers(): HttpHeaders {
+    return new HttpHeaders({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${environment.startggApiToken}`
+    });
+  }
+
+  getTournament(slug: string): Observable<GgTournament> {
+    const query = `query Tournament($slug: String!) {\n  tournament(slug: $slug) {\n    id\n    name\n    slug\n  }\n}`;
+    return this.post(query, { slug }).pipe(
+      map(res => this.mapTournament(res))
+    );
+  }
+
+  getPlayers(eventId: number): Observable<GgPlayer[]> {
+    const query = `query EventPlayers($eventId: ID!) {\n  event(id: $eventId) {\n    entrants(query: {page: 1, perPage: 50}) {\n      nodes {\n        id\n        participants {\n          gamerTag\n        }\n      }\n    }\n  }\n}`;
+    return this.post(query, { eventId }).pipe(
+      map(res => this.mapPlayers(res))
+    );
+  }
+
+  getSets(eventId: number): Observable<GgSet[]> {
+    const query = `query EventSets($eventId: ID!) {\n  event(id: $eventId) {\n    sets(page: 1, perPage: 50) {\n      nodes {\n        id\n        winnerId\n        slots {\n          entrant { id }\n        }\n      }\n    }\n  }\n}`;
+    return this.post(query, { eventId }).pipe(
+      map(res => this.mapSets(res))
+    );
+  }
+
+  // exposed for unit testing
+  mapTournament(response: any): GgTournament {
+    const t = response.data.tournament;
+    return { id: Number(t.id), name: t.name, slug: t.slug };
+  }
+
+  // exposed for unit testing
+  mapPlayers(response: any): GgPlayer[] {
+    const nodes = response.data.event.entrants.nodes as any[];
+    return nodes.map(n => ({ id: Number(n.id), tag: n.participants[0].gamerTag }));
+  }
+
+  // exposed for unit testing
+  mapSets(response: any): GgSet[] {
+    const nodes = response.data.event.sets.nodes as any[];
+    return nodes.map(n => ({
+      id: n.id,
+      winnerId: Number(n.winnerId),
+      entrantIds: n.slots.map((s: any) => Number(s.entrant.id))
+    }));
+  }
+
+  private post(query: string, variables: any): Observable<any> {
+    return this.http.post<any>(this.apiUrl, { query, variables }, { headers: this.headers });
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,6 @@
 export const environment = {
-  production: true
+  production: true,
+  // Token used for authenticating requests to start.gg GraphQL API
+  // Populate this value through environment specific configuration during build
+  startggApiToken: ''
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,10 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  // Token used for authenticating requests to start.gg GraphQL API
+  // Replace with your personal access token in a local environment file
+  startggApiToken: ''
 };
 
 /*

--- a/src/models/startgg.ts
+++ b/src/models/startgg.ts
@@ -1,0 +1,16 @@
+export interface GgTournament {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+export interface GgPlayer {
+  id: number;
+  tag: string;
+}
+
+export interface GgSet {
+  id: string;
+  winnerId: number;
+  entrantIds: number[];
+}


### PR DESCRIPTION
## Summary
- add a Start.gg Angular service for calling the GraphQL API
- expose functions to request tournaments, players, and sets
- make API token configurable via environment files
- cover the data mapping logic with unit tests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655fda603c8327bfee49adb5af6c45