### PR TITLE
Add power ranking service

### DIFF
--- a/src/app/power-rankings/power-rankings.component.html
+++ b/src/app/power-rankings/power-rankings.component.html
@@ -1,42 +1,19 @@
 <div class="power-rankings__header">
     <h2>Power Rankings</h2>
-    <p>Last updated: April 20, 1991</p>
 </div>
-<div class="power-rankings__container">
-    <div class="power-rankings__player-cards">
-        <app-player-card
-        [playerId]="samplePlayers[0]"
-        [rank]="1">
-        </app-player-card>
-        <app-player-card
-        [playerId]="samplePlayers[1]"
-        [rank]="2">
-        </app-player-card>
-        <app-player-card 
-        [playerId]="samplePlayers[2]"
-        [rank]="3">
-        </app-player-card>
-        <app-player-card 
-        [playerId]="samplePlayers[3]"
-        [rank]="4">
-        </app-player-card>
-    </div>
-    <div class="power-rankings__player-cards">
-        <app-player-card 
-        [playerId]="samplePlayers[4]"
-        [rank]="5">
-        </app-player-card>
-        <app-player-card 
-        [playerId]="samplePlayers[5]"
-        [rank]="6">
-        </app-player-card>
-        <app-player-card 
-        [playerId]="samplePlayers[6]"
-        [rank]="7">
-        </app-player-card>
-        <app-player-card
-        [playerId]="samplePlayers[7]"
-        [rank]="8">
-        </app-player-card>
-    </div>
-</div>
+<table>
+  <tr>
+    <th>Rank</th>
+    <th>Player</th>
+    <th>Wins</th>
+    <th>Losses</th>
+    <th>Appearances</th>
+  </tr>
+  <tr *ngFor="let r of records; index as i">
+    <td>{{ i + 1 }}</td>
+    <td>{{ r.tag }}</td>
+    <td>{{ r.wins }}</td>
+    <td>{{ r.losses }}</td>
+    <td>{{ r.appearances }}</td>
+  </tr>
+</table>

--- a/src/app/power-rankings/power-rankings.component.spec.ts
+++ b/src/app/power-rankings/power-rankings.component.spec.ts
@@ -1,6 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PowerRankingsComponent } from './power-rankings.component';
+import { PowerRankingService, PlayerRecord } from '../services/power-ranking.service';
+
+class MockPowerRankingService {
+  computeSeason() { return Promise.resolve([] as PlayerRecord[]); }
+}
 
 describe('PowerRankingsComponent', () => {
   let component: PowerRankingsComponent;
@@ -8,7 +13,8 @@ describe('PowerRankingsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ PowerRankingsComponent ]
+      declarations: [ PowerRankingsComponent ],
+      providers: [ { provide: PowerRankingService, useClass: MockPowerRankingService } ]
     })
     .compileComponents();
   });

--- a/src/app/power-rankings/power-rankings.component.ts
+++ b/src/app/power-rankings/power-rankings.component.ts
@@ -1,8 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Fighter } from 'src/models/fighter';
-import { FighterService } from '../services/fighter.service';
-import { Player } from 'src/models/player';
-import { PlayerService } from '../services/player.service';
+import { PlayerRecord, PowerRankingService } from '../services/power-ranking.service';
 
 @Component({
   selector: 'app-power-rankings',
@@ -11,19 +8,12 @@ import { PlayerService } from '../services/player.service';
 })
 export class PowerRankingsComponent implements OnInit {
 
-  samplePlayers: number[] = [];
+  records: PlayerRecord[] = [];
 
-  constructor(
-    private fighterService: FighterService,
-    private playerService: PlayerService
-  ) {
-   }
+  constructor(private prService: PowerRankingService) {}
 
   ngOnInit(): void {
+    // Example event ids array; in a real app these would be provided by user input
+    this.prService.computeSeason([]).then(r => this.records = r);
   }
-
-  buildPlayer(playerId: number): Player {
-    return this.playerService.players[playerId];
-  }
-
 }

--- a/src/app/services/power-ranking.service.spec.ts
+++ b/src/app/services/power-ranking.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { GgPlayer, GgSet } from 'src/models/startgg';
+import { PowerRankingService } from './power-ranking.service';
+import { StartggService } from './startgg.service';
+
+class MockStartggService {
+  players: { [id: number]: GgPlayer[] } = {};
+  sets: { [id: number]: GgSet[] } = {};
+
+  getPlayers(eventId: number) {
+    return of(this.players[eventId] || []);
+  }
+  getSets(eventId: number) {
+    return of(this.sets[eventId] || []);
+  }
+}
+
+describe('PowerRankingService', () => {
+  let service: PowerRankingService;
+  let mock: MockStartggService;
+
+  beforeEach(() => {
+    mock = new MockStartggService();
+    TestBed.configureTestingModule({
+      providers: [
+        PowerRankingService,
+        { provide: StartggService, useValue: mock }
+      ]
+    });
+    service = TestBed.inject(PowerRankingService);
+  });
+
+  it('computes simple rankings', async () => {
+    mock.players[1] = [
+      { id: 1, tag: 'A' },
+      { id: 2, tag: 'B' }
+    ];
+    mock.sets[1] = [
+      { id: '1', winnerId: 1, entrantIds: [1, 2] }
+    ];
+    const records = await service.computeSeason([1]);
+    expect(records.length).toBe(2);
+    expect(records[0].id).toBe(1);
+    expect(records[0].wins).toBe(1);
+    expect(records[1].losses).toBe(1);
+    expect(records[0].headToHead[2].wins).toBe(1);
+    expect(records[1].headToHead[1].losses).toBe(1);
+  });
+});

--- a/src/app/services/power-ranking.service.ts
+++ b/src/app/services/power-ranking.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { GgPlayer, GgSet } from 'src/models/startgg';
+import { StartggService } from './startgg.service';
+
+export interface PlayerRecord {
+  id: number;
+  tag: string;
+  wins: number;
+  losses: number;
+  appearances: number;
+  headToHead: { [opponentId: number]: { wins: number; losses: number } };
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PowerRankingService {
+  private records = new Map<number, PlayerRecord>();
+
+  constructor(private startgg: StartggService) {}
+
+  getRecord(id: number): PlayerRecord | undefined {
+    return this.records.get(id);
+  }
+
+  getRecords(): PlayerRecord[] {
+    return Array.from(this.records.values()).sort((a, b) => {
+      const awr = a.wins / Math.max(1, a.wins + a.losses);
+      const bwr = b.wins / Math.max(1, b.wins + b.losses);
+      if (awr === bwr) return b.wins - a.wins;
+      return bwr - awr;
+    });
+  }
+
+  async computeSeason(eventIds: number[]): Promise<PlayerRecord[]> {
+    this.records.clear();
+    for (const id of eventIds) {
+      const players = await firstValueFrom(this.startgg.getPlayers(id));
+      const sets = await firstValueFrom(this.startgg.getSets(id));
+      players.forEach(p => this.ensureRecord(p));
+      this.processSets(sets);
+      players.forEach(p => {
+        const rec = this.records.get(p.id)!;
+        rec.appearances++;
+      });
+    }
+    return this.getRecords();
+  }
+
+  private ensureRecord(p: GgPlayer): void {
+    if (!this.records.has(p.id)) {
+      this.records.set(p.id, {
+        id: p.id,
+        tag: p.tag,
+        wins: 0,
+        losses: 0,
+        appearances: 0,
+        headToHead: {}
+      });
+    }
+  }
+
+  private processSets(sets: GgSet[]): void {
+    for (const s of sets) {
+      if (s.entrantIds.length < 2) continue;
+      const [p1, p2] = s.entrantIds;
+      const winner = s.winnerId;
+      const loser = winner === p1 ? p2 : p1;
+      const wRec = this.records.get(winner)!;
+      const lRec = this.records.get(loser)!;
+      wRec.wins++;
+      lRec.losses++;
+      this.updateH2h(wRec, loser, true);
+      this.updateH2h(lRec, winner, false);
+    }
+  }
+
+  private updateH2h(rec: PlayerRecord, oppId: number, win: boolean): void {
+    if (!rec.headToHead[oppId]) {
+      rec.headToHead[oppId] = { wins: 0, losses: 0 };
+    }
+    if (win) {
+      rec.headToHead[oppId].wins++;
+    } else {
+      rec.headToHead[oppId].losses++;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `PowerRankingService` for computing rankings from StartGG data
- wire rankings into `PowerRankingsComponent`
- display computed rankings
- add unit tests for ranking logic

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686561960ef483278853c75cd1daed59