### PR TITLE
Improve home page layout

### DIFF
--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,27 +1,28 @@
-@media screen and (max-width: 768px) {
-  .menu-cards-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-    margin-top: 16px;
-  }
+/* Modern home page layout */
+
+.page-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 16px;
+  background: linear-gradient(to bottom right, #1e1e1e, #3a3a3a);
 }
 
-@media screen and (min-width: 768px) {
-  .menu-cards-container {
-    margin: 0 16px;
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
-    align-content: center;
-    height: 50vh;
-  }
+.banner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 24px;
+}
 
-  .banner-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100%;
-  }
+.menu-cards-container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  padding: 0 16px 32px;
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -15,13 +15,11 @@
 
   </div>
 <div class="menu-cards-container">
-  <div class="menu-card">
-    <app-menu-card
+  <app-menu-card
     [headerText]="'Stage List and Bans Tool'"
     [infoText]="'All SEMO Smash events use the same stage list.'"
     [url]="'stage-list-bans-full'">
-    </app-menu-card>
-  </div>
+  </app-menu-card>
   <!-- Community component is dead lol -->
   <!-- <div class="menu-card">
     <app-menu-card [headerText]="'Community'"

--- a/src/app/menu-card/menu-card.component.css
+++ b/src/app/menu-card/menu-card.component.css
@@ -28,6 +28,20 @@
   }
 }
 
+/* Hover effect for menu cards */
+.menu-card {
+  cursor: pointer;
+}
+
+.menu-card .mat-card {
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.menu-card:hover .mat-card {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
+}
+
 
 
 .menu-card__header {


### PR DESCRIPTION
## Summary
- modernize home page layout with a gradient background and responsive grid
- clean up home page markup
- add hover effects to menu cards

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869eb99f230832787dd5882b225d9d9