### PR TITLE
Redesign mobile navigation to swipeable home menu cards

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,96 +1,31 @@
-/* FILEPATH: /Users/benasselmeier/Workspace/cape-smash/src/app/app.component.css */
-
-/* Styles for the whole app */
-@media screen and (max-width: 768px) {
-  .page-container {
-    background-color: blue;
-    margin: 0;
-    display: column;
-    gap: 16px;
-  }
+.app-container {
+  display: flex;
+  min-height: 100vh;
+  margin: 0;
+  padding: 0;
 }
 
-/* App-wide layout with sidebar */
-@media screen and (max-width: 768px) {
-  .app-container {
-    display: flex;
-    flex-direction: column;
-    margin: 0;
-    padding: 0;
-    min-height: 100vh;
-  }
-  
-  .sidebar-container {
-    width: 100%;
-    background-color: #333333;
-    border-radius: 0;
-    overflow: hidden;
-    margin-bottom: 20px;
-  }
-  
-  .main-content {
-    flex: 1;
-    padding: 0;
-    margin: 0;
-  }
-}
-
-@media screen and (min-width: 768px) {
-  .app-container {
-    display: flex;
-    min-height: 100vh;
-    margin: 0;
-    padding: 0;
-  }
-  
-  .sidebar-container {
-    width: 300px;
-    background-color: #333333;
-    border-radius: 0;
-    overflow: hidden;
-    position: fixed;
-    left: 0;
-    top: 0;
-    height: 100vh;
-    z-index: 200;
-    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.8);
-    border-right: 2px solid rgba(255, 255, 255, 0.15);
-  }
-  
-  .main-content {
-    flex: 1;
-    margin-left: 250px;
-    padding: 0;
-    min-height: 100vh;
-  }
-}
-
-/* Responsive adjustments for smaller laptop screens */
-@media screen and (max-width: 1400px) and (min-width: 768px) {
-  .sidebar-container {
-    width: 250px; /* Reduce main sidebar width */
-  }
-  
-  .main-content {
-    margin-left: 250px;
-  }
-}
-
-@media screen and (max-width: 1200px) and (min-width: 768px) {
-  .sidebar-container {
-    width: 200px; /* Further reduce main sidebar width */
-  }
-  
-  .main-content {
-    margin-left: 200px;
-  }
-}
-
-/* Sidebar Groups */
 .sidebar-container {
+  width: 300px;
+  background-color: #333333;
+  border-radius: 0;
+  overflow: hidden;
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100vh;
+  z-index: 200;
+  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.8);
+  border-right: 2px solid rgba(255, 255, 255, 0.15);
   display: flex;
   flex-direction: column;
-  height: 100%;
+}
+
+.main-content {
+  flex: 1;
+  margin-left: 300px;
+  padding: 0;
+  min-height: 100vh;
 }
 
 .sidebar-group {
@@ -108,113 +43,34 @@
   margin-top: auto;
 }
 
-/* Mobile top navigation and hamburger button */
-.mobile-topnav {
-  display: none;
-}
-
-.hamburger {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  margin: 8px;
-  z-index: 300;
-}
-
-.hamburger span {
-  display: block;
-  height: 4px;
-  width: 28px;
-  background: #fff;
-  margin: 4px 0;
-  border-radius: 2px;
-  transition: 0.3s;
-}
-
-.mobile-title {
-  color: #fff;
-  font-size: 1.2em;
-  font-weight: bold;
-  margin-left: 8px;
-  align-self: center;
-}
-
-@media screen and (max-width: 768px) {
-  .mobile-topnav {
-    display: flex;
-    align-items: center;
-    background: #222;
-    height: 56px;
-    width: 100vw;
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: 300;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
-    padding-left: 0;
-  }
-  .app-container {
-    padding-top: 56px;
-  }
+@media screen and (max-width: 1400px) and (min-width: 769px) {
   .sidebar-container {
-    position: fixed;
-    top: 56px;
-    left: 0;
-    width: 80vw;
-    max-width: 320px;
-    height: calc(100vh - 56px);
-    z-index: 250;
-    transform: translateX(-100%);
-    transition: transform 0.3s cubic-bezier(.4,0,.2,1);
-    box-shadow: 4px 0 20px rgba(0,0,0,0.8);
+    width: 250px;
   }
-  .sidebar-container.sidebar-hidden {
-    transform: translateX(-100%);
-  }
-  .sidebar-container:not(.sidebar-hidden) {
-    transform: translateX(0);
-  }
+
   .main-content {
-    margin-left: 0;
-    padding: 0;
-    min-height: calc(100vh - 56px);
-    background: #222;
-  }
-  body.sidebar-open {
-    overflow: hidden;
+    margin-left: 250px;
   }
 }
 
-@media screen and (min-width: 769px) {
-  .mobile-topnav {
+@media screen and (max-width: 1200px) and (min-width: 769px) {
+  .sidebar-container {
+    width: 200px;
+  }
+
+  .main-content {
+    margin-left: 200px;
+  }
+}
+
+/* On mobile, hide sidebar and use the home menu carousel instead. */
+@media screen and (max-width: 768px) {
+  .sidebar-container {
     display: none;
   }
-  .sidebar-container {
-    transform: none !important;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 300px;
-    height: 100vh;
-    z-index: 200;
-  }
+
   .main-content {
-    margin-left: 300px;
-    padding: 0;
+    margin-left: 0;
     min-height: 100vh;
   }
-}
-
-/* Debugging styles */
-.sidebar-debug-test {
-  background: red;
-  color: white;
-  padding: 20px;
-  margin: 10px;
-  font-weight: bold;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,71 +1,32 @@
 <div class="app-container">
-  <!-- Top nav bar for mobile -->
-  <div class="mobile-topnav">
-    <button class="hamburger" (click)="toggleSidebar()" aria-label="Open menu">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <span class="mobile-title">SEMO Smash</span>
-  </div>
-
-  <!-- Sidebar -->
   <div class="sidebar-container" [class.sidebar-hidden]="sidebarHiddenOnMobile">
-    <!-- Main navigation group -->
     <div class="sidebar-group sidebar-main">
-      <app-menu-card 
+      <app-menu-card
         [headerText]="'Home'"
         [infoText]="''"
         [url]="'/'"
         [sidebarStyle]="true"
         (menuCardClicked)="closeSidebarOnMobile()">
       </app-menu-card>
-      
-      <app-menu-card 
+
+      <app-menu-card
         [headerText]="'Stage List and Bans Tool'"
         [infoText]="'All SEMO Smash events use the same stage list.'"
         [url]="'stage-list-bans-full'"
         [sidebarStyle]="true"
         (menuCardClicked)="closeSidebarOnMobile()">
       </app-menu-card>
-      
-      <app-menu-card 
-        [headerText]="'Tournaments'" 
+
+      <app-menu-card
+        [headerText]="'Tournaments'"
         [infoText]="'View a list of our regular events with quick links!'"
         [url]="'tournaments'"
         [sidebarStyle]="true"
         (menuCardClicked)="closeSidebarOnMobile()">
       </app-menu-card>
-      
-      <app-menu-card 
-        [headerText]="'Season 6: Three Houses'" 
-        [infoText]="'Follow the Three Houses competition and view standings!'"
-        [url]="'season-6'"
-        [sidebarStyle]="true"
-        (menuCardClicked)="closeSidebarOnMobile()">
-      </app-menu-card>
-      
-      <app-menu-card 
-        [headerText]="'Power Rankings'" 
-        [infoText]="'See the top SEMO Smash players ranked by skill!'"
-        [url]="'power-rankings'"
-        [isDisabled]="true"
-        [disabledStatusText]="'Coming soon!'"
-        [disabledMessage]="'Power rankings feature is currently being developed.'"
-        [sidebarStyle]="true"
-        (menuCardClicked)="closeSidebarOnMobile()">
-      </app-menu-card>
-      
-      <app-menu-card 
-        [headerText]="'Socials'" 
-        [infoText]="'Connect with the SEMO Smash community online!'"
-        [url]="'community'"
-        [sidebarStyle]="true"
-        (menuCardClicked)="closeSidebarOnMobile()">
-      </app-menu-card>
-      
-      <app-menu-card 
-        [headerText]="'Streams, VODs & Content'" 
+
+      <app-menu-card
+        [headerText]="'Streams, VODs & Content'"
         [infoText]="'Watch tournaments, streams, and community content'"
         [url]="'streaming'"
         [sidebarStyle]="true"
@@ -73,18 +34,17 @@
       </app-menu-card>
     </div>
 
-    <!-- Bottom group for contact and source code -->
     <div class="sidebar-group sidebar-bottom">
-      <app-menu-card 
-        [headerText]="'Contact'" 
+      <app-menu-card
+        [headerText]="'Contact'"
         [infoText]="''"
         [url]="'mailto:mbsmashacct@gmail.com'"
         [sidebarStyle]="true"
         (menuCardClicked)="closeSidebarOnMobile()">
       </app-menu-card>
-      
-      <app-menu-card 
-        [headerText]="'Source Code'" 
+
+      <app-menu-card
+        [headerText]="'Source Code'"
         [infoText]="''"
         [url]="'https://github.com/mbsmash/cape-smash'"
         [sidebarStyle]="true"
@@ -93,8 +53,7 @@
     </div>
   </div>
 
-  <!-- Main content area -->
-  <div class="main-content" (click)="closeSidebarOnMobile()">
+  <div class="main-content">
     <router-outlet></router-outlet>
   </div>
 </div>

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,4 +1,3 @@
-
 .home-container {
   display: flex;
   justify-content: center;
@@ -14,7 +13,7 @@
   border-radius: 10px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   overflow: hidden;
-  max-width: 800px;
+  max-width: 900px;
   width: 100%;
   border: 1px solid #333;
 }
@@ -24,70 +23,104 @@
   color: white;
   text-align: center;
   padding: 20px;
-  margin: 0;
   border-bottom: 2px solid #555;
 }
 
-.welcome-header h1 {
-  margin: 0;
-  font-size: 2.5em;
-  font-weight: bold;
-  font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
-  color: #fff;
+.welcome-content { padding: 24px; text-align: center; }
+.greeting-section h2 { color: #ffa500; margin-bottom: 12px; }
+.greeting-section p { color: #ccc; margin-bottom: 20px; }
+
+.mobile-main-menu {
+  display: none;
 }
 
-.welcome-content {
-  padding: 30px;
-  text-align: center;
-  background-color: #2a2a2a;
-}
-
-.greeting-section h2 {
-  color: #ffa500;
-  margin-bottom: 15px;
-  font-size: 2em;
-  font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
-}
-
-.greeting-section p {
-  color: #ccc;
-  font-size: 1.2em;
-  margin-bottom: 30px;
-  line-height: 1.5;
-}
-
-.welcome-footer {
-  background-color: #2a2a2a;
-  text-align: center;
-  padding: 15px;
-  color: #999;
-  font-style: italic;
-  border-top: 1px solid #333;
-}
-
-/* Mobile Styles */
 @media screen and (max-width: 768px) {
   .home-container {
-    padding: 10px;
-    min-height: 70vh;
-    background-color: #1a1a1a;
+    padding: 0;
+    min-height: 100vh;
   }
-  
+
   .welcome-card {
-    max-width: 100%;
+    border-radius: 0;
+    border: none;
+    min-height: 100vh;
   }
-  
-  .welcome-header h1 {
-    font-size: 2em;
+
+  .welcome-content {
+    padding: 18px 14px 28px;
   }
-  
-  .greeting-section h2 {
-    font-size: 1.5em;
-    color: #ffa500;
+
+  .stream-embed-container {
+    margin-bottom: 12px;
   }
-  
-  .greeting-section p {
-    font-size: 1em;
-    color: #ccc;
+
+  .mobile-main-menu {
+    display: block;
+    margin-top: 8px;
   }
+
+  .mobile-main-menu h3 {
+    color: #f0f0f0;
+    text-align: left;
+    margin: 0 0 12px;
+    letter-spacing: 0.04em;
+  }
+
+  .card-deck-window {
+    display: grid;
+    grid-template-columns: 36px 1fr 36px;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .deck-nav {
+    height: 48px;
+    border: 1px solid #606060;
+    border-radius: 24px;
+    background: #3a3a3a;
+    color: #fff;
+    font-size: 30px;
+    line-height: 1;
+  }
+
+  .deck-card {
+    position: relative;
+    height: 230px;
+    border: none;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+  }
+
+  .deck-card-layer {
+    position: absolute;
+    inset: 0;
+    border-radius: 18px;
+  }
+
+  .deck-card-back {
+    transform: translate(10px, 10px) scale(0.98);
+    background: #3f3f3f;
+  }
+
+  .deck-card-mid {
+    transform: translate(5px, 5px) scale(0.99);
+    background: #555;
+  }
+
+  .deck-card-front {
+    background: linear-gradient(165deg, #f3f3f3 0%, #d8d8d8 100%);
+    color: #1e1e1e;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 10px;
+    padding: 18px;
+    text-align: left;
+    border: 1px solid #bbbbbb;
+  }
+
+  .deck-card-title { font-weight: 700; font-size: 1.25rem; margin: 0; }
+  .deck-card-description { margin: 0; font-size: 0.92rem; color: #404040; }
+  .deck-card-meta { margin: 0; font-size: 0.78rem; color: #6b6b6b; }
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -3,8 +3,9 @@
     <div class="welcome-header">
       <h1>SEMO Smash Hub v2</h1>
     </div>
+
     <div class="welcome-content">
-      <div *ngIf="liveVideoId; else showHomeContent" class="stream-embed-container">
+      <div *ngIf="liveVideoId" class="stream-embed-container">
         <iframe
           width="100%"
           height="500"
@@ -15,20 +16,30 @@
           title="SEMO Smash Live Stream">
         </iframe>
       </div>
-      <ng-template #showHomeContent>
-        <div class="greeting-section">
-          <h2>Welcome to our new online portal!</h2>
-          <p>Explore the sidebar to dive into our community features!</p>
-          <p>Please note that this portal is under construction. Some features may not be fully implemented or work as intended. Thank you for your patience! </p>
-          <p>Any feedback or issues can be reported by using the Contact link in the sidebar or by contacting MB on Discord.</p>
+
+      <div class="greeting-section">
+        <h2>Welcome to our online portal!</h2>
+        <p>Swipe the cards below to browse the main tools and links.</p>
+      </div>
+
+      <div class="mobile-main-menu" (touchstart)="onTouchStart($event)" (touchend)="onTouchEnd($event)">
+        <h3>Main Menu</h3>
+        <div class="card-deck-window">
+          <button class="deck-nav deck-nav-left" (click)="previousCard()" aria-label="Previous menu card">‹</button>
+
+          <button class="deck-card" (click)="openCurrentCard()" [attr.aria-label]="homeMenuOptions[activeCardIndex].title">
+            <div class="deck-card-layer deck-card-back"></div>
+            <div class="deck-card-layer deck-card-mid"></div>
+            <div class="deck-card-layer deck-card-front">
+              <p class="deck-card-title">{{ homeMenuOptions[activeCardIndex].title }}</p>
+              <p class="deck-card-description">{{ homeMenuOptions[activeCardIndex].description }}</p>
+              <p class="deck-card-meta">{{ activeCardIndex + 1 }} / {{ homeMenuOptions.length }}</p>
+            </div>
+          </button>
+
+          <button class="deck-nav deck-nav-right" (click)="nextCard()" aria-label="Next menu card">›</button>
         </div>
-        <div class="stream-embed-container">
-          <p>No live stream is currently active.</p>
-        </div>
-      </ng-template>
-    </div>
-    <div class="welcome-footer">
-      <p>What's new: site redesign!</p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,12 @@
 import { Component, OnInit } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
-import { MenuCardComponent } from '../menu-card/menu-card.component';
 import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+
+interface HomeMenuOption {
+  title: string;
+  description: string;
+  url: string;
+}
 
 @Component({
   selector: 'app-home',
@@ -10,25 +15,91 @@ import { HttpClient } from '@angular/common/http';
 })
 export class HomeComponent implements OnInit {
   liveVideoId: string | null = null;
-  channelId = 'UCpElhVL_GGDDA8gYb7jA2Aw'; // TODO: Replace with your channel's ID
-  apiKey = 'AIzaSyBb1XT-tjN-uDf6xP-hDnvJExM1_Pp0gFI'; // TODO: Replace with your YouTube Data API v3 key
+  channelId = 'UCpElhVL_GGDDA8gYb7jA2Aw';
+  apiKey = 'AIzaSyBb1XT-tjN-uDf6xP-hDnvJExM1_Pp0gFI';
 
-  constructor(private http: HttpClient) { }
+  homeMenuOptions: HomeMenuOption[] = [
+    {
+      title: 'Stage List and Bans Tool',
+      description: 'Quick access to the unified ruleset used at SEMO Smash events.',
+      url: 'stage-list-bans-full'
+    },
+    {
+      title: 'Tournaments',
+      description: 'Current and recurring tournament information and links.',
+      url: 'tournaments'
+    },
+    {
+      title: 'Streams, VODs & Content',
+      description: 'Watch live streams, VODs, and community content.',
+      url: 'streaming'
+    },
+    {
+      title: 'Contact',
+      description: 'Get in touch with the SEMO Smash organizers.',
+      url: 'mailto:mbsmashacct@gmail.com'
+    },
+    {
+      title: 'Source Code',
+      description: 'See the project repository and open-source code.',
+      url: 'https://github.com/mbsmash/cape-smash'
+    }
+  ];
+
+  activeCardIndex = 0;
+  private touchStartX = 0;
+
+  constructor(private http: HttpClient, private router: Router) { }
 
   ngOnInit(): void {
-    this.fetchLiveStreamId(); // Restore dynamic fetching of your channel's live stream
+    this.fetchLiveStreamId();
   }
 
   fetchLiveStreamId() {
     const url = `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${this.channelId}&eventType=live&type=video&key=${this.apiKey}`;
     this.http.get<any>(url).subscribe(res => {
-      if (res.items && res.items.length > 0) {
-        this.liveVideoId = res.items[0].id.videoId;
-      } else {
-        this.liveVideoId = null;
-      }
-    }, err => {
+      this.liveVideoId = res.items && res.items.length > 0 ? res.items[0].id.videoId : null;
+    }, () => {
       this.liveVideoId = null;
     });
+  }
+
+  onTouchStart(event: TouchEvent): void {
+    this.touchStartX = event.changedTouches[0].screenX;
+  }
+
+  onTouchEnd(event: TouchEvent): void {
+    const delta = event.changedTouches[0].screenX - this.touchStartX;
+    if (Math.abs(delta) < 35) {
+      return;
+    }
+
+    if (delta < 0) {
+      this.nextCard();
+    } else {
+      this.previousCard();
+    }
+  }
+
+  nextCard(): void {
+    this.activeCardIndex = (this.activeCardIndex + 1) % this.homeMenuOptions.length;
+  }
+
+  previousCard(): void {
+    this.activeCardIndex = (this.activeCardIndex - 1 + this.homeMenuOptions.length) % this.homeMenuOptions.length;
+  }
+
+  openCurrentCard(): void {
+    this.openOption(this.homeMenuOptions[this.activeCardIndex].url);
+  }
+
+  openOption(url: string): void {
+    if (url.startsWith('http')) {
+      window.open(url, '_blank');
+    } else if (url.startsWith('mailto:')) {
+      window.location.href = url;
+    } else {
+      this.router.navigateByUrl(url);
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Simplify and modernize mobile navigation by removing the mobile sidebar/hamburger pattern and surfacing primary actions on the home page as a card deck. 
- Surface only the most-used options for now and sweep seasonal/rankings features out of primary navigation while keeping their code intact. 

### Description
- Replaced mobile sidebar with a home-page main menu carousel and hid the sidebar on small screens via CSS in `src/app/app.component.css`. 
- Implemented a multitasking-style deck-of-cards carousel on the home page with swipe support, previous/next controls, and tap-to-open behavior in `src/app/home/home.component.ts`, `src/app/home/home.component.html`, and `src/app/home/home.component.css`. 
- Reduced visible navigation options to `Stage List and Bans Tool`, `Tournaments`, `Streams, VODs & Content`, `Contact`, and `Source Code`, keeping desktop sidebar navigation for larger screens in `src/app/app.component.html`. 

### Testing
- Ran a production build with `npm run build`, which produced CSS build errors due to pre-existing missing font assets referenced from `src/styles.css` and therefore failed to complete. 
- The build produced additional non-blocking warnings (autoprefixer notes and CommonJS dependency warnings) but no new runtime/test failures attributable to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076f80b9d08327abbd69332e38f6d8)